### PR TITLE
Intention-Based - Preventive Maintenance

### DIFF
--- a/application/src/test/java/org/thingsboard/server/system/BaseHttpDeviceApiTest.java
+++ b/application/src/test/java/org/thingsboard/server/system/BaseHttpDeviceApiTest.java
@@ -17,6 +17,12 @@ package org.thingsboard.server.system;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.thingsboard.server.common.data.DeviceTransportType;
+import org.thingsboard.server.common.transport.TransportService;
+import org.thingsboard.server.gen.transport.TransportProtos;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -29,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
@@ -42,14 +49,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @TestPropertySource(properties = {
         "transport.http.enabled=true",
+        "transport.rate_limits.ip_block_timeout=6000",
+        "transport.rate_limits.max_wrong_credentials_per_ip=10",
+        "transport.rate_limits.ip_limits_enabled=true",
         "transport.http.max_payload_size=/api/v1/*/rpc/**=10000;/api/v1/**=20000"
 })
 public abstract class BaseHttpDeviceApiTest extends AbstractControllerTest {
 
     private static final AtomicInteger idSeq = new AtomicInteger(new Random(System.currentTimeMillis()).nextInt());
-
     protected Device device;
     protected DeviceCredentials deviceCredentials;
+    private long ipBlockTimeout = 6000;
+    private int maxWrongCredentialsPerIp = 10;
+    @SpyBean
+    private TransportService transportService;
 
     @Before
     public void before() throws Exception {
@@ -64,6 +77,27 @@ public abstract class BaseHttpDeviceApiTest extends AbstractControllerTest {
     }
 
     @Test
+    public void testRateLimits_wrongCredentialsMaxOut() throws Exception {
+        doGetAsync("/api/v1/" + deviceCredentials.getCredentialsId() + "/attributes?clientKeys=keyA,keyB,keyC")
+                .andExpect(status().isOk());
+
+        for (int i = 0; i < maxWrongCredentialsPerIp; i++) {
+            doGetAsync("/api/v1/" + "WRONG_TOKEN" + "/attributes?clientKeys=keyA,keyB,keyC")
+                    .andExpect(status().is(401));
+        }
+        Mockito.verify(transportService, Mockito.times(maxWrongCredentialsPerIp + 1))
+                .process(Mockito.any(DeviceTransportType.class), Mockito.any(TransportProtos.ValidateDeviceTokenRequestMsg.class), Mockito.any());
+        mockMvc.perform(get("/api/v1/" + deviceCredentials.getCredentialsId() + "/attributes?clientKeys=keyA,keyB,keyC"))
+                .andExpect(status().is(401));
+
+        Mockito.verify(transportService, Mockito.times(maxWrongCredentialsPerIp + 1))
+                .process(Mockito.any(DeviceTransportType.class), Mockito.any(TransportProtos.ValidateDeviceTokenRequestMsg.class), Mockito.any());
+        Thread.sleep(ipBlockTimeout);
+        doGetAsync("/api/v1/" + deviceCredentials.getCredentialsId() + "/attributes?clientKeys=keyA,keyB,keyC")
+                .andExpect(status().isOk());
+    }
+
+    @Test
     public void testGetAttributes() throws Exception {
         doGetAsync("/api/v1/" + "WRONG_TOKEN" + "/attributes?clientKeys=keyA,keyB,keyC").andExpect(status().isUnauthorized());
         doGetAsync("/api/v1/" + deviceCredentials.getCredentialsId() + "/attributes?clientKeys=keyA,keyB,keyC").andExpect(status().isOk());
@@ -71,7 +105,7 @@ public abstract class BaseHttpDeviceApiTest extends AbstractControllerTest {
         Map<String, String> attrMap = new HashMap<>();
         attrMap.put("keyA", "valueA");
         mockMvc.perform(
-                asyncDispatch(doPost("/api/v1/" + deviceCredentials.getCredentialsId() + "/attributes", attrMap, new String[]{}).andReturn()))
+                        asyncDispatch(doPost("/api/v1/" + deviceCredentials.getCredentialsId() + "/attributes", attrMap, new String[]{}).andReturn()))
                 .andExpect(status().isOk());
         Thread.sleep(2000);
         doGetAsync("/api/v1/" + deviceCredentials.getCredentialsId() + "/attributes?clientKeys=keyA,keyB,keyC").andExpect(status().isOk());

--- a/common/transport/http/pom.xml
+++ b/common/transport/http/pom.xml
@@ -75,6 +75,12 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/common/transport/http/src/main/java/org/thingsboard/server/transport/http/DeviceApiController.java
+++ b/common/transport/http/src/main/java/org/thingsboard/server/transport/http/DeviceApiController.java
@@ -81,7 +81,7 @@ import java.util.function.Consumer;
  * @author Andrew Shvayka
  */
 @RestController
-@ConditionalOnExpression("'${service.type:null}'=='tb-transport' || ('${service.type:null}'=='monolith' && '${transport.api_enabled:true}'=='true' && '${transport.http.enabled}'=='true')")
+@TbHttpTransportComponent
 @RequestMapping("/api/v1")
 @Slf4j
 public class DeviceApiController implements TbTransportService {

--- a/common/transport/http/src/main/java/org/thingsboard/server/transport/http/HttpTransportContext.java
+++ b/common/transport/http/src/main/java/org/thingsboard/server/transport/http/HttpTransportContext.java
@@ -20,17 +20,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.coyote.http11.Http11NioProtocol;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 import org.thingsboard.server.common.transport.TransportContext;
+import java.net.InetSocketAddress;
 
 /**
  * Created by ashvayka on 04.10.18.
  */
 @Slf4j
-@ConditionalOnExpression("'${service.type:null}'=='tb-transport' || ('${service.type:null}'=='monolith' && '${transport.api_enabled:true}'=='true' && '${transport.http.enabled}'=='true')")
+@TbHttpTransportComponent
 @Component
 public class HttpTransportContext extends TransportContext {
 
@@ -52,4 +52,17 @@ public class HttpTransportContext extends TransportContext {
             }
         };
     }
+
+    public boolean checkAddress(InetSocketAddress address) {
+        return rateLimitService.checkAddress(address);
+    }
+
+    public void onAuthSuccess(InetSocketAddress address) {
+        rateLimitService.onAuthSuccess(address);
+    }
+
+    public void onAuthFailure(InetSocketAddress address) {
+        rateLimitService.onAuthFailure(address);
+    }
+
 }

--- a/common/transport/http/src/main/java/org/thingsboard/server/transport/http/RateLimitsInterceptorsConfig.java
+++ b/common/transport/http/src/main/java/org/thingsboard/server/transport/http/RateLimitsInterceptorsConfig.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.http;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.thingsboard.server.transport.http.limits.IpRateLimitInterceptor;
+
+@TbHttpTransportComponent
+@Configuration
+public class RateLimitsInterceptorsConfig implements WebMvcConfigurer {
+    private final HttpTransportContext context;
+
+    public RateLimitsInterceptorsConfig(HttpTransportContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new IpRateLimitInterceptor(context)).addPathPatterns("/api/v1/**");
+    }
+}

--- a/common/transport/http/src/main/java/org/thingsboard/server/transport/http/TbHttpTransportComponent.java
+++ b/common/transport/http/src/main/java/org/thingsboard/server/transport/http/TbHttpTransportComponent.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.http;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@ConditionalOnExpression("'${service.type:null}'=='tb-transport' || ('${service.type:null}'=='monolith' && '${transport.api_enabled:true}'=='true' && '${transport.http.enabled}'=='true')")
+public @interface TbHttpTransportComponent {
+}

--- a/common/transport/http/src/main/java/org/thingsboard/server/transport/http/limits/IpRateLimitInterceptor.java
+++ b/common/transport/http/src/main/java/org/thingsboard/server/transport/http/limits/IpRateLimitInterceptor.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.http.limits;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+import org.thingsboard.server.transport.http.HttpTransportContext;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.net.InetSocketAddress;
+import java.util.Enumeration;
+
+public class IpRateLimitInterceptor implements HandlerInterceptor {
+    private final HttpTransportContext ctx;
+
+    public IpRateLimitInterceptor(HttpTransportContext context){
+        this.ctx = context;
+    }
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) throws Exception {
+
+        if (ctx.checkAddress(getInetSocketAddress(request))){
+            return true;
+        } else {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            return false;
+        }
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request,
+                           HttpServletResponse response,
+                           Object handler,
+                           @Nullable ModelAndView modelAndView) throws Exception {
+        int status = response.getStatus();
+        InetSocketAddress addr = getInetSocketAddress(request);
+        if (status != HttpStatus.UNAUTHORIZED.value()){
+            ctx.onAuthSuccess(addr);
+        } else {
+            ctx.onAuthFailure(addr);
+        }
+    }
+
+    @NotNull
+    private InetSocketAddress getInetSocketAddress(HttpServletRequest request) {
+        Enumeration<String> headers = request.getHeaders("X-Forwarded-For");
+        String addr;
+        if (headers.hasMoreElements()) {
+            addr = headers.nextElement();
+        } else {
+            addr = request.getRemoteAddr();
+        }
+        return new InetSocketAddress(addr, request.getRemotePort());
+    }
+
+}


### PR DESCRIPTION
## Reengineering Task: Control the incoming HTTP requests to ThingsBoard's HTTP transport layer

Name: Tan Jia Xuan
Matric No.: U2102793/1
Project: Thingsboard

-----

### Addressed Issue 
The lack of rate limiting posed a risk of server overloading due to high traffic volumes or malicious requests, potentially leading to degraded performance or service disruptions. The PR involved implementing a new mechanism to regulate incoming HTTP requests, providing a safeguard against these potential issues. 

-----

### Key Changes
In this PR, there were a total of 4 files were changed and 3 new files were added.
![image](https://github.com/user-attachments/assets/76aacef6-30fc-478f-abd9-58277d3fda51)

A new HTTP interceptor was introduced to enforce rate limiting at the HTTP transport layer. This component works by controlling the flow of incoming requests, applying rules and limits to ensure the server processes requests in a controlled manner. By integrating this new interceptor, the PR effectively adds a layer of resilience, enhancing the robustness of the HTTP communication channel in ThingsBoard.
![image](https://github.com/user-attachments/assets/ca3283b6-ad15-4dbf-a73c-3a17bd605dd0)
![image](https://github.com/user-attachments/assets/b6e0b129-f95f-46de-afc1-25a3e9abf044)

Also, test cases are added to verify the functionality of the new HTTP interceptor and ensure that the rate limiting behaves as expected under various scenarios.
![image](https://github.com/user-attachments/assets/c22676a3-b598-4e11-8512-7330f6434e51)


-----
### Justification: Preventive Maintenance under Intention-Based Classification Software Maintenance
The task falls under Preventive Maintenance because:
* Prevention of Security Issues: The changes control incoming HTTP requests to prevent malicious attacks such as SQL injection, cross-site scripting (XSS), or denial of service (DoS). 
* Prevention of Performance Degradation: It prevents system overloading by controlling the number of concurrent requests.
* Controlling HTTP requests is not done to fix existing issues (corrective maintenance) or add new features (perfective maintenance). Instead, it serves to avert future problems by preemptively handling potential risks. This aligns with preventive maintenance's goal to avoid defects or system degradation over time.
* No Immediate Problem Fixing: Unlike corrective maintenance, controlling HTTP requests does not fix an existing failure or defect.

-----
### Impact of the Changes
![image](https://github.com/user-attachments/assets/466c16f8-e90f-4c3c-8e7e-ff9a4b9aa65d)
* Added test case: The test case for this PR passed successfully.
* Enhanced performance stability: By limiting the rate of incoming HTTP requests, the system can prevent overloading, ensuring stable performance even under high traffic loads.
* Improve security and resilience: Rate limiting acts as a protective mechanism against potential abuse, such as Denial-of-Service (DoS) attacks, which could otherwise disrupt service availability.
* Improve maintainability: The new interceptor component can be adjusted or extended as needed, providing flexibility for future enhancements and maintaining the modularity of the ThingsBoard architecture.
* Better Resource Utilization: By regulating request flows, server resources are used more efficiently, avoiding excessive strain and allowing the system to handle legitimate requests effectively.
-----
### Summary/Screenshots
![Screenshot of Postman - Unauthorized when more than 10 requests](https://github.com/user-attachments/assets/e83fc221-f9a0-4e12-bf02-993dccace6f6)
The code enables HTTP transport and IP-based rate limiting with a block timeout of 6000 ms after 10 failed attempts. 